### PR TITLE
Correct reading of results from findProfiles query

### DIFF
--- a/workloads/userProfile.go
+++ b/workloads/userProfile.go
@@ -51,6 +51,10 @@ type User struct {
 	Enabled bool
 }
 
+type UserQueryResponse struct {
+	Profiles User
+}
+
 type runctx struct {
 	r rand.Rand
 	l zap.Logger
@@ -147,12 +151,12 @@ func findProfile(ctx context.Context, rctx runctx) {
 	}
 
 	for rows.Next() {
-		var u User
-		err := rows.Row(&u)
+		var resp UserQueryResponse
+		err := rows.Row(&resp)
 		if err != nil {
 			rctx.l.Error("Could not read next row.", zap.Error(err))
 		}
-		rctx.l.Sugar().Debugf("Found a User: %s", u)
+		rctx.l.Sugar().Debugf("Found a User: %+v", resp.Profiles)
 	}
 
 	err = rows.Err()


### PR DESCRIPTION
Currently we read the rows of the query response in `findProfile` directly into the `User` struct. This does not error but nothing is read into the struct, as shown in the logs:

```
Found a User: {  0001-01-01 00:00:00 +0000 UTC  %!s(bool=false)}
```

This is because the User data is nested inside a `profiles` object, this PR handles this nesting, resulting in the User data being read correctly: 

```
2024-11-05T13:35:06.952Z	DEBUG	workloads/userProfile.go:159	Found a User: {Gilberto Corwin serenitysmitham@hane.info 2015-10-02 10:35:11.15479618 +0000 UTC Iure dolor assumenda ex quia expedita sed culpa sint cumque. Repellendus minima cupiditate commodi voluptatum est id facilis iusto aliquid. Praesentium nisi ut neque saepe dolor quas eius quidem qui. Ea quaerat at accusantium cum rem cumque excepturi ullam minima. %!s(bool=true)}
```