### PR TITLE
Data api implementation

### DIFF
--- a/spectroperf.go
+++ b/spectroperf.go
@@ -81,7 +81,7 @@ func main() {
 	zap.L().Info("Setting up for workload…\n")
 
 	// call the setup function on the workload.
-	workloads.Setup(flags.numItems, flags.numUsers, bucket.Scope(flags.scope), collection)
+	workloads.Setup(flags.numItems, flags.numUsers, bucket.Scope(flags.scope), collection, flags.dapiConnstr, flags.username, flags.password)
 
 	time.Sleep(5 * time.Second)
 
@@ -93,20 +93,22 @@ func main() {
 }
 
 type Flags struct {
-	connstr    string
-	cert       string
-	username   string
-	password   string
-	bucket     string
-	scope      string
-	collection string
-	numItems   int
-	numUsers   int
+	connstr     string
+	dapiConnstr string
+	cert        string
+	username    string
+	password    string
+	bucket      string
+	scope       string
+	collection  string
+	numItems    int
+	numUsers    int
 }
 
 func parseFlags() Flags {
 	flags := Flags{}
 	flag.StringVar(&flags.connstr, "connstr", "", "connection string of the cluster under test")
+	flag.StringVar(&flags.dapiConnstr, "dapi-connstr", "", "connection for data api")
 	flag.StringVar(&flags.cert, "cert", "rootCA.crt", "path to certificate file")
 	flag.StringVar(&flags.username, "username", "Administrator", "username for cluster under test")
 	flag.StringVar(&flags.password, "password", "password", "password of the cluster under test")

--- a/workloads/userClient/dapiClient.go
+++ b/workloads/userClient/dapiClient.go
@@ -1,0 +1,139 @@
+package userClient
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+type DapiUserQueryResponse struct {
+	Results []UserQueryResponse `json:"results"`
+}
+
+type DapiQueryPayload struct {
+	Statement string `json:"statement"`
+}
+
+type dapiClient struct {
+	connstr    string
+	bucket     string
+	scope      string
+	collection string
+	username   string
+	password   string
+	client     *http.Client
+}
+
+func NewDapiClient(connstr string, bucket string, scope string, collection string, username string, password string) *dapiClient {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &dapiClient{
+		connstr:    connstr,
+		bucket:     bucket,
+		scope:      scope,
+		collection: collection,
+		username:   username,
+		password:   password,
+		client:     &http.Client{Transport: tr},
+	}
+}
+
+func (c *dapiClient) executeRequest(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(c.username, c.password)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute get request: %s", err.Error())
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("profile fetch returned unexpected status code %d", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+func (c *dapiClient) GetUser(ctx context.Context, id string) (*User, error) {
+	requestURL := fmt.Sprintf("%s/v1/buckets/%s/scopes/%s/collections/%s/documents/%s", c.connstr, c.bucket, c.scope, c.collection, id)
+	req, err := http.NewRequest("GET", requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build profile fetch request: %s", err.Error())
+	}
+
+	resp, err := c.executeRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch profile to update: %s", err.Error())
+	}
+
+	bodyText, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body: %s", err.Error())
+	}
+
+	var toUd User
+	err = json.Unmarshal(bodyText, &toUd)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal response body - %s : %s", string(bodyText), err.Error())
+	}
+	return &toUd, nil
+}
+
+func (c *dapiClient) UpsertUser(ctx context.Context, id string, user User) error {
+	requestURL := fmt.Sprintf("%s/v1/buckets/%s/scopes/%s/collections/%s/documents/%s", c.connstr, c.bucket, c.scope, c.collection, id)
+
+	jsonBytes, err := json.Marshal(user)
+	if err != nil {
+		return fmt.Errorf("could not marshal User to json: &s", err.Error())
+	}
+
+	req, err := http.NewRequest("PUT", requestURL, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("failed to build profile update request: %s", err.Error())
+	}
+
+	_, err = c.executeRequest(req)
+	if err != nil {
+		return fmt.Errorf("error executing upsert request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (c *dapiClient) FindUser(ctx context.Context, query string) (*User, error) {
+	payload := DapiQueryPayload{
+		Statement: query,
+	}
+	requestURL := fmt.Sprintf("%s/_p/query/query/service", c.connstr)
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build profile fetch request: %s", err.Error())
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.executeRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not execute query request: %s", err.Error())
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body: %s", err.Error())
+	}
+
+	var results DapiUserQueryResponse
+	err = json.Unmarshal(bodyBytes, &results)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal response body - %s : %s", string(bodyBytes), err.Error())
+	}
+
+	if len(results.Results) > 0 {
+		return &results.Results[0].Profiles, nil
+	}
+	return nil, fmt.Errorf("could not find user")
+}

--- a/workloads/userClient/sdkClient.go
+++ b/workloads/userClient/sdkClient.go
@@ -1,0 +1,63 @@
+package userClient
+
+import (
+	"context"
+	"fmt"
+	"github.com/couchbase/gocb/v2"
+)
+
+type sdkClient struct {
+	scope      gocb.Scope
+	collection gocb.Collection
+}
+
+func NewSdkClient(scope gocb.Scope, collection gocb.Collection) *sdkClient {
+	return &sdkClient{
+		scope:      scope,
+		collection: collection,
+	}
+}
+
+func (c *sdkClient) GetUser(ctx context.Context, id string) (*User, error) {
+	result, err := c.collection.Get(id, &gocb.GetOptions{Context: ctx})
+	if err != nil {
+		return nil, fmt.Errorf("profile fetch failed: %s", err.Error())
+	}
+
+	var toUd User
+	err = result.Content(&toUd)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load user into struct: %s", err.Error())
+	}
+
+	return &toUd, nil
+}
+
+func (c *sdkClient) UpsertUser(ctx context.Context, id string, user User) error {
+	_, err := c.collection.Upsert(id, user, nil)
+	if err != nil {
+		return fmt.Errorf("data load upsert failed: %s", err.Error())
+	}
+	return nil
+}
+
+func (c *sdkClient) FindUser(ctx context.Context, query string) (*User, error) {
+	rows, err := c.scope.Query(query, &gocb.QueryOptions{Adhoc: true})
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %s", err.Error())
+	}
+
+	var resp UserQueryResponse
+	for rows.Next() {
+		err := rows.Row(&resp)
+		if err != nil {
+			return nil, fmt.Errorf("could not read next row: %s", err.Error())
+		}
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, fmt.Errorf("error iterating the rows: %s", err.Error())
+	}
+	return &resp.Profiles, nil
+}

--- a/workloads/userClient/userClient.go
+++ b/workloads/userClient/userClient.go
@@ -1,0 +1,24 @@
+package userClient
+
+import (
+	"context"
+	"time"
+)
+
+type User struct {
+	Name    string
+	Email   string
+	Created time.Time
+	Status  string
+	Enabled bool
+}
+
+type UserQueryResponse struct {
+	Profiles User `json:"profiles"`
+}
+
+type UserClient interface {
+	GetUser(ctx context.Context, id string) (*User, error)
+	UpsertUser(ctx context.Context, id string, user User) error
+	FindUser(ctx context.Context, query string) (*User, error)
+}


### PR DESCRIPTION
With this implementation running against DataAPI would be done as follows: 

```
go run spectroperf.go --connstr couchbase://192.168.107.128 --dapi-connstr https://localhost:18100
```

Spectroperf will use the first connstr to connect to the cluster and load all the data, then for the actual workload the Data API connstr will be used. 