### PR TITLE
Consolidate numUsers and numItems variables

### DIFF
--- a/spectroperf.go
+++ b/spectroperf.go
@@ -82,7 +82,7 @@ func main() {
 	zap.L().Info("Setting up for workload…\n")
 
 	// call the setup function on the workload.
-	workloads.Setup(flags.numItems, flags.numUsers, bucket.Scope(flags.scope), collection)
+	workloads.Setup(flags.numUsers, bucket.Scope(flags.scope), collection)
 
 	time.Sleep(5 * time.Second)
 
@@ -101,7 +101,6 @@ type Flags struct {
 	bucket        string
 	scope         string
 	collection    string
-	numItems      int
 	numUsers      int
 	tlsSkipVerify bool
 }
@@ -115,7 +114,6 @@ func parseFlags() Flags {
 	flag.StringVar(&flags.bucket, "bucket", "data", "bucket name")
 	flag.StringVar(&flags.scope, "scope", "identity", "scope name")
 	flag.StringVar(&flags.collection, "collection", "profiles", "collection name")
-	flag.IntVar(&flags.numItems, "num-items", 200000, "number of docs to create")
 	flag.IntVar(&flags.numUsers, "num-users", 50000, "number of concurrent simulated users accessing the data")
 	flag.BoolVar(&flags.tlsSkipVerify, "tls-skip-verify", false, "skip TLS certificate verification")
 	flag.Parse()


### PR DESCRIPTION
There are a couple of issues with the workload preparation:

1. When uploading documents we create a thread for each user (default 50000), this results in `queue overflow` errors being returned from gocb, since we are submitting operations faster than gocb can handle them. Therefore we should limit the number of concurrent upload threads to a constant reasonable value, chosen to be 2000.

```
{"level":"error","ts":1731318879.087214,"caller":"workloads/userProfile.go:402","msg":"Data load upsert failed.: queue overflowed | {\"document_key\":\"u25483\",\"bucket\":\"data\",\"scope\":\"identity\",\"collection\":\"profiles\",\"collection_id\":10}","stacktrace":"github.com/couchbaselabs/spectroperf/workloads.loadData.func1\n\t/Users/jackwestwood/spectroperf/workloads/userProfile.go:402"}
```

2. When generating IDs of documents to perform operations against we use the numItems value. This works fine until the number of users exceeds the number of items. Since this workload represents user profiles, we need one profile per user so we should upload a document for each user, generate the ids from number of users and remove the numItems variable. 