### PR TITLE
Move random sleep before call to operation function

### DIFF
--- a/workloads/userProfile.go
+++ b/workloads/userProfile.go
@@ -347,6 +347,10 @@ func runLoop(
 			slog.Debug(nextFunction)
 			attemptMetrics[nextFunction].Inc()
 
+			// sleep a random amount of time
+			t := r.Int31n(5000-400) + 400
+			time.Sleep(time.Duration(t) * time.Millisecond)
+
 			start := time.Now()
 			err := functions[operations[nextOpIndex]](ctx, runCtx)
 			duration := time.Now().Sub(start)
@@ -359,9 +363,6 @@ func runLoop(
 
 			// update for next time
 			currOpIndex = nextOpIndex
-			// sleep a random amount of time
-			t := r.Int31n(5000-400) + 400
-			time.Sleep(time.Duration(t) * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
Currently we let the go routine sleep for a random amount of time at the end of the run loop. The issue here is that on the first iteration of the loop all the routines will be attempting to execute their operations at the same time. This leads to the gocb queue overflowing and returning errors. This PR moves the sleep to before the first execution so that the routines will be staggered from the start. 