### PR TITLE
Add buckets for smaller latencies to duration histogram

### DIFF
--- a/workload/metrics.go
+++ b/workload/metrics.go
@@ -22,7 +22,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "operation_duration_milliseconds",
 			Help:    "Duration of user operations in milliseconds, partitioned by operation.",
-			Buckets: []float64{25.0, 50.0, 100.0, 250.0, 500.0, 1500.0, 2500.0},
+			Buckets: []float64{0.150, 0.225, 0.338, 0.506, 0.759, 1.139, 1.709, 2.563, 3.844, 5.767, 8.650, 12.975, 19.462, 29.193, 43.789, 65.684, 98.526, 147.789, 221.684, 332.526, 498.789, 748.183, 1122.274, 1683.411, 2525.117},
 		},
 		[]string{"operation"},
 	)


### PR DESCRIPTION
Before using HDR histogram to find the best bucket values using a geometric series is an improvement that is an improvement over the current values, and does well enough for initial testing.