### PR TITLE
Change findProfiles query to reduce KV load

### DIFF
--- a/workload/workloads/userProfile.go
+++ b/workload/workloads/userProfile.go
@@ -144,7 +144,7 @@ func (w userProfile) lockProfile(ctx context.Context, rctx workload.Runctx) erro
 func (w userProfile) findProfile(ctx context.Context, rctx workload.Runctx) error {
 	toFind := fmt.Sprintf("%s%%", gofakeit.Letter())
 
-	query := "SELECT * FROM profiles WHERE Email LIKE $email LIMIT 1"
+	query := "SELECT meta().id FROM profiles WHERE Email LIKE $email LIMIT 1"
 	rctx.Logger().Sugar().Debugf("Querying with %s using param %s", query, toFind)
 	params := make(map[string]interface{}, 1)
 	params["email"] = toFind


### PR DESCRIPTION
After looking into the failures from the query service, it seems that the query being used was causing the issue. Originally we were doing “SELECT *” which requires KV ops to get the whole document. Since we are putting pressure on KV with other KV ops this part of the query was slow, the query request queue would fill up and requests would start being denied. This PR changes the query to "SELECT meta().id" removing the KV ops from the query.