### PR TITLE
Implement findRelatedProfiles

### DIFF
--- a/spectroperf.go
+++ b/spectroperf.go
@@ -112,7 +112,7 @@ func main() {
 	var w workload.Workload
 	switch config.Workload {
 	case "user-profile":
-		w = workloads.NewUserProfile(config.NumItems, bucket.Scope(config.Scope), collection)
+		w = workloads.NewUserProfile(config.NumItems, bucket.Scope(config.Scope), collection, *cluster)
 	case "user-profile-dapi":
 		w = workloads.NewUserProfileDapi(config.DapiConnstr, config.Bucket, config.Scope, config.Collection, config.NumItems, config.Username, config.Password)
 	default:

--- a/spectroperf.go
+++ b/spectroperf.go
@@ -112,9 +112,9 @@ func main() {
 	var w workload.Workload
 	switch config.Workload {
 	case "user-profile":
-		w = workloads.NewUserProfile(config.NumItems, bucket.Scope(config.Scope), collection, *cluster)
+		w = workloads.NewUserProfile(config.NumItems, bucket.Scope(config.Scope), collection, cluster)
 	case "user-profile-dapi":
-		w = workloads.NewUserProfileDapi(config.DapiConnstr, config.Bucket, config.Scope, config.Collection, config.NumItems, config.Username, config.Password)
+		w = workloads.NewUserProfileDapi(config.DapiConnstr, config.Bucket, config.Scope, collection, config.NumItems, config.Username, config.Password, cluster)
 	default:
 		zap.L().Fatal("Unknown workload type", zap.String("workload", config.Workload))
 	}

--- a/workload/workload.go
+++ b/workload/workload.go
@@ -70,6 +70,7 @@ func Setup(w Workload, numItemsArg int, scp *gocb.Scope, coll *gocb.Collection) 
 	shutdownChan := make(chan struct{}, numConc)
 	var wg sync.WaitGroup
 
+	zap.L().Info("Inserting documents", zap.Int("number of docs", numItemsArg))
 	wg.Add(numConc)
 	for i := 0; i < numConc; i++ {
 		go func() {

--- a/workload/workloads/userProfile.go
+++ b/workload/workloads/userProfile.go
@@ -19,10 +19,10 @@ type userProfile struct {
 	numItems   int
 	scope      *gocb.Scope
 	collection *gocb.Collection
-	cluster    gocb.Cluster
+	cluster    *gocb.Cluster
 }
 
-func NewUserProfile(numItems int, scope *gocb.Scope, collection *gocb.Collection, cluster gocb.Cluster) userProfile {
+func NewUserProfile(numItems int, scope *gocb.Scope, collection *gocb.Collection, cluster *gocb.Cluster) userProfile {
 	return userProfile{
 		numItems:   numItems,
 		scope:      scope,
@@ -117,12 +117,12 @@ func (w userProfile) Probabilities() [][]float64 {
 func (w userProfile) Setup() error {
 	gofakeit.Seed(int64(workload.RandSeed))
 
-	err := createQueryIndex(w.collection)
+	err := CreateQueryIndex(w.collection)
 	if err != nil {
 		return err
 	}
 
-	err = createFtsIndexes(w.cluster)
+	err = CreateFtsIndexes(w.cluster)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (w userProfile) Setup() error {
 	return nil
 }
 
-func createQueryIndex(collection *gocb.Collection) error {
+func CreateQueryIndex(collection *gocb.Collection) error {
 	mgr := collection.QueryIndexes()
 	err := mgr.CreateIndex("eMailIndex", []string{"Email"}, &gocb.CreateQueryIndexOptions{
 		IgnoreIfExists: true,
@@ -143,7 +143,7 @@ func createQueryIndex(collection *gocb.Collection) error {
 	return nil
 }
 
-func createFtsIndexes(cluster gocb.Cluster) error {
+func CreateFtsIndexes(cluster *gocb.Cluster) error {
 	indexName := "interest-index"
 	mgr := cluster.SearchIndexes()
 

--- a/workload/workloads/userProfile.go
+++ b/workload/workloads/userProfile.go
@@ -306,11 +306,13 @@ func (w userProfile) findRelatedProfiles(ctx context.Context, rctx workload.Runc
 		return fmt.Errorf("fts query failed: %s", err.Error())
 	}
 
+	var matchingUsers []string
 	for matchResult.Next() {
 		row := matchResult.Row()
-		docID := row.ID
-		rctx.Logger().Sugar().Debugf("Found user %s with matching interests", docID)
+		matchingUsers = append(matchingUsers, row.ID)
 	}
+
+	rctx.Logger().Sugar().Debugf("Found users interested in %s: %v\n", interestToFind, matchingUsers)
 
 	err = matchResult.Err()
 	if err != nil {

--- a/workload/workloads/userProfileDapi.go
+++ b/workload/workloads/userProfileDapi.go
@@ -114,7 +114,7 @@ func (w userProfileDapi) Setup() error {
 		return err
 	}
 
-	err = CreateFtsIndexes(w.cluster)
+	err = EnsureFtsIndex(w.cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR implements `findRelatedProfiles` for use-profile and user-profile Dapi.

Each User now has an extra field `Interests` which is a random comma separated list of interests from the hardcoded array.

`findRelatedProfiles` chooses a random interest from the array and performs an FTS search to find profiles that share that interest. 