### PR TITLE
Conditional cert reading

### DIFF
--- a/workload/workloads/userProfileDapi.go
+++ b/workload/workloads/userProfileDapi.go
@@ -3,7 +3,6 @@ package workloads
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"github.com/brianvoe/gofakeit"
@@ -31,7 +30,6 @@ type userProfileDapi struct {
 func NewUserProfileDapi(connstr string, bucket string, scope string, collection string, numItems int, usr string, pwd string) userProfileDapi {
 	tr := otelhttp.NewTransport(
 		&http.Transport{
-			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 			MaxConnsPerHost:     500,
 			MaxIdleConnsPerHost: 100,
 		},


### PR DESCRIPTION
There are a couple of issues surrounding TLS certs in spectroperf that this PR addresses: 

1. We always try to read a TLS cert even though we allow TLS to be disabled, we should only read a cert when a path is specified
2. When certs were given we were not adding them to the caCert pool when connecting to the cluster
3. The data API workload was skipping TLS verification, but we should always verify since the DAPI cert is signed by go Daddy