### PR TITLE
Correctly set the markov chain when using in built probabilities

### DIFF
--- a/spectroperf.go
+++ b/spectroperf.go
@@ -147,7 +147,7 @@ func main() {
 
 	if len(markovChain) == 0 {
 		zap.L().Info("neither markov chain or only operation specified, using built in workload proabilities")
-		config.MarkovChain = w.Probabilities()
+		markovChain = w.Probabilities()
 	}
 
 	workload.InitMetrics(w)


### PR DESCRIPTION
When making the change to make the Markov chain configurable the case where inbuilt workload probabilities are used has a bug that results in the markov chain not being set, causing a panic when the array is accessed. 