### PR TITLE
Correct error handling on index creation

### DIFF
--- a/workload/workloads/userProfile.go
+++ b/workload/workloads/userProfile.go
@@ -193,7 +193,7 @@ func EnsureFtsIndex(cluster *gocb.Cluster) error {
 		PlanParams:   nil,
 	}, nil)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	zap.L().Info("Checking fts index is ready to use", zap.String("name", indexName))


### PR DESCRIPTION
When there is an error, we shouldn't swallow it on index creation.