### PR TITLE
Create indexes for correct bucket, scope and collection

### DIFF
--- a/spectroperf.go
+++ b/spectroperf.go
@@ -134,7 +134,7 @@ func main() {
 	var w workload.Workload
 	switch config.Workload {
 	case "user-profile":
-		w = workloads.NewUserProfile(config.NumItems, bucket.Scope(config.Scope), collection, cluster)
+		w = workloads.NewUserProfile(config.NumItems, bucket.Name(), bucket.Scope(config.Scope), collection, cluster)
 	case "user-profile-dapi":
 		w = workloads.NewUserProfileDapi(config.DapiConnstr, config.Bucket, config.Scope, collection, config.NumItems, config.Username, config.Password, cluster)
 	default:

--- a/workload/workloads/userProfileDapi.go
+++ b/workload/workloads/userProfileDapi.go
@@ -5,17 +5,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/brianvoe/gofakeit"
-	"github.com/couchbase/gocb/v2"
-	"github.com/couchbaselabs/spectroperf/workload"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptrace"
 	"strings"
 	"time"
+
+	"github.com/brianvoe/gofakeit"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbaselabs/spectroperf/workload"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 type userProfileDapi struct {
@@ -114,7 +115,7 @@ func (w userProfileDapi) Setup() error {
 		return err
 	}
 
-	err = EnsureFtsIndex(w.cluster)
+	err = EnsureFtsIndex(w.cluster, w.bucket, w.scope, w.collection.Name())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Addresses: https://github.com/couchbaselabs/spectroperf/issues/49

Currently while spectroperf supports the overriding of the default bucket/scope/collection these values are not correctly used when creating indexes and generating queries which can lead to failures. This PR makes sure that these settings are correctly used and failures avoided. 